### PR TITLE
add manage-fastapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 - [FastAPI Versioning](https://github.com/DeanWay/fastapi-versioning) - API versioning.
 - [Jupyter Notebook REST API](https://github.com/Invictify/Jupter-Notebook-REST-API) - Run your Jupyter notebooks as RESTful API endpoints.
 - [msgpack-asgi](https://github.com/florimondmanca/msgpack-asgi) - Automatic [MessagePack](https://msgpack.org/) content negotiation.
-- [Manage FastAPI](https://github.com/ycd/manage-fastapi) - Command-line project management tool for FastAPI. Generate projects Django-admin like . 
+- [Manage FastAPI](https://github.com/ycd/manage-fastapi) - Command-line project management tool for FastAPI. Generates projects Django-admin like. 
 
 ### Email
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,13 @@
 - [FastAPI-CamelCase](https://ahmednafies.github.io/fastapi_camelcase/) - CamelCase JSON support for FastAPI utilizing [Pydantic](https://pydantic-docs.helpmanual.io/).
   - [CamelCase Models with FastAPI and Pydantic](https://medium.com/analytics-vidhya/camel-case-models-with-fast-api-and-pydantic-5a8acb6c0eee) - Accompanying blog post from the author of the extension.
 
-
 ### Developer Tools
 
 - [FastAPI Client Generator](https://github.com/dmontagu/fastapi_client) - Generate a mypy- and IDE-friendly API client from an OpenAPI spec.
 - [FastAPI Versioning](https://github.com/DeanWay/fastapi-versioning) - API versioning.
 - [Jupyter Notebook REST API](https://github.com/Invictify/Jupter-Notebook-REST-API) - Run your Jupyter notebooks as RESTful API endpoints.
+- [Manage FastAPI](https://github.com/ycd/manage-fastapi) - CLI tool for generating and managing FastAPI projects.
 - [msgpack-asgi](https://github.com/florimondmanca/msgpack-asgi) - Automatic [MessagePack](https://msgpack.org/) content negotiation.
-- [Manage FastAPI](https://github.com/ycd/manage-fastapi) - Command-line project management tool for FastAPI. Generates projects Django-admin like. 
 
 ### Email
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - [FastAPI Versioning](https://github.com/DeanWay/fastapi-versioning) - API versioning.
 - [Jupyter Notebook REST API](https://github.com/Invictify/Jupter-Notebook-REST-API) - Run your Jupyter notebooks as RESTful API endpoints.
 - [msgpack-asgi](https://github.com/florimondmanca/msgpack-asgi) - Automatic [MessagePack](https://msgpack.org/) content negotiation.
+- [Manage FastAPI](https://github.com/ycd/manage-fastapi) - Command-line project management tool for FastAPI. Generate projects Django-admin like . 
 
 ### Email
 


### PR DESCRIPTION
I started this project to create Django-admin like management tool, in (short-term) 8 days i added basic functionalites of django-admin

- startproject
- startapp
- showmodels
- runserver


it already got a thousand of downloads in 8 days, validation: https://pepy.tech/project/manage-fastapi
In long term, like we discussed in reddit i will add _user interface for managing data based on the models_ etc.