### PR TITLE
Add Deta

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@
 - [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
 - [Google App Engine](https://cloud.google.com/appengine/)
 - [Microsoft Azure App Service](https://azure.microsoft.com/services/app-service/)
-- [Deta](https://www.deta.sh/) – Deploy unlimited FastAPI apps in seconds for free. Inludes built-in DB and auth. [Tutorial](https://dev.to/athulcajay/fastapi-deta-ni5)
+- [Deta](https://www.deta.sh/) ([example](https://dev.to/athulcajay/fastapi-deta-ni5))
 
 ### IaaS
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@
 - [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
 - [Google App Engine](https://cloud.google.com/appengine/)
 - [Microsoft Azure App Service](https://azure.microsoft.com/services/app-service/)
-- [Deta](https://www.deta.sh/) – Deploy unlimited FastAPI apps in seconds for free. Inludes built-in DB and auth.
+- [Deta](https://www.deta.sh/) – Deploy unlimited FastAPI apps in seconds for free. Inludes built-in DB and auth. [Tutorial](https://dev.to/athulcajay/fastapi-deta-ni5)
 
 ### IaaS
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 - [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
 - [Google App Engine](https://cloud.google.com/appengine/)
 - [Microsoft Azure App Service](https://azure.microsoft.com/services/app-service/)
+- [Deta](https://www.deta.sh/) – Deploy unlimited FastAPI apps in seconds for free. Inludes built-in DB and auth.
 
 ### IaaS
 


### PR DESCRIPTION
Hi Michael, I added Deta as a PaaS for FastAPI.
We actually designed Deta Micros with FastAPI in mind (but also support any ASGI and WSGI apps).

The deployment is painless, just run `deta new` in the project's root. Example: https://github.com/abdelhai/stockscreener
We offer a generous free tier and thought the community might appreciate it. Cheers!