### PR TITLE
Remove PythonAnywhere from hosting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@
 (Platforms-as-a-Service)
 
 - [Heroku](https://www.heroku.com/)
-- [PythonAnywhere](https://www.pythonanywhere.com/details/flask_hosting)
 - [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
 - [Google App Engine](https://cloud.google.com/appengine/)
 - [Microsoft Azure App Service](https://azure.microsoft.com/services/app-service/)


### PR DESCRIPTION
PythonAnywhere does not allow FastApi hosting at the moment.