### PR TITLE
Add tutorial on getting FastAPI to play with Jinja and Templates, and to let users download results

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@
 - [Porting Flask to FastAPI for ML Model Serving](https://www.pluralsight.com/tech-blog/porting-flask-to-fastapi-for-ml-model-serving/) - Comparison of Flask vs FastAPI.
 - [Real-time data streaming using FastAPI and WebSockets](https://stribny.name/blog/2020/07/real-time-data-streaming-using-fastapi-and-websockets) - Learn how to stream data from FastAPI directly into a real-time chart.
 - [Serving Machine Learning Models with FastAPI in Python](https://medium.com/@8B_EC/tutorial-serving-machine-learning-models-with-fastapi-in-python-c1a27319c459) - Use FastAPI to quickly and easily deploy and serve machine learning models in Python as a RESTful API.
+- [How to Set Up a HTML App with FastAPI, Jinja, Forms & Templates](https://eugeneyan.com/writing/how-to-set-up-html-app-with-fastapi-jinja-forms-templates/) - Building simple demos with FastAPI, Jinja forms (for input) and Templates
+- [Adding a Checkbox & Download Button to a FastAPI-HTML app](https://eugeneyan.com/writing/fastapi-html-checkbox-download/) - Adding a download button for users to save results
 
 ### Talks
 


### PR DESCRIPTION
While I was trying to build a prototype to demo my ML models, it was difficult to find tutorials on building simple FastAPI frontends. Here's my small contribution to plug the hole in the internet. For the front end, it has:
- Jinja (for easy HTML templates)
- Forms (to allow users to enter input)
- Download button (to allow download of results)

Repo for the tutorial here: [`fastapi-html`](https://github.com/eugeneyan/fastapi-html)