### PR TITLE
Adding updated links to Tortoise ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@
 #### ORMs
 
 - [FastAPI SQLAlchemy](https://github.com/mfreeborn/fastapi-sqlalchemy) - Simple integration between FastAPI and [SQLAlchemy](https://www.sqlalchemy.org/).
-- [Tortoise ORM](https://tortoise.github.io/) - An easy-to-use asyncio ORM (Object Relational Mapper) inspired by Django.
+- [Tortoise ORM](https://tortoise-orm.readthedocs.io/en/latest/index.html) - An easy-to-use asyncio ORM (Object Relational Mapper) inspired by Django.
   - [FastAPI Example](https://tortoise-orm.readthedocs.io/en/latest/examples/fastapi.html) - An example of the Tortoise-ORM FastAPI integration.
   - [Tutorial: Setting up Tortoise ORM with FastAPI](https://web.archive.org/web/20200523174158/https://robwagner.dev/tortoise-fastapi-setup/)
-  - [Aerich](https://github.com/tortoise/aerich) - Tortoise ORM migrations tools.
+  - [Aerich](https://tortoise-orm.readthedocs.io/en/latest/migration.html) - Tortoise ORM migrations tools.
 - [GINO](https://github.com/python-gino/gino) - A lightweight asynchronous ORM built on top of SQLAlchemy core for Python asyncio.
   - [FastAPI Example](https://github.com/leosussan/fastapi-gino-arq-uvicorn)
 - [ORM](https://github.com/encode/orm) - An async ORM.


### PR DESCRIPTION
Tortoise ORM link points to version 0.16.14. Updated link to point to lastest 0.16.17. Also added link to Aerich. The TortoiseORM docs now have a section within it called migrations that documents how to use Aerich with a little walk-through example. 