### PR TITLE
add fastapi-jwt-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@
 
 - [FastAPI Auth](https://github.com/dmontagu/fastapi-auth) - Pluggable auth that supports the OAuth2 Password Flow with JWT access and refresh tokens.
 - [FastAPI Login](https://github.com/MushroomMaula/fastapi_login) - Account management and authentication (based on [Flask-Login](https://github.com/maxcountryman/flask-login)).
+- [FastAPI JWT Auth](https://github.com/IndominusByte/fastapi-jwt-auth) - JWT auth (based on [Flask-JWT-Extended](https://github.com/vimalloc/flask-jwt-extended)).
 - [FastAPI Permissions](https://github.com/holgi/fastapi-permissions) - Row-level permissions.
 - [FastAPI Security](https://github.com/jmagnusson/fastapi-security) - Implements authentication and authorization as dependencies in FastAPI.
 - [FastAPI Simple Security](https://github.com/mrtolkien/fastapi_simple_security) - Out-of-the-box API key security manageable through path operations.
 - [FastAPI Users](https://github.com/frankie567/fastapi-users) - Account management, authentication, authorization.
-- [FastAPI JWT Auth](https://github.com/IndominusByte/fastapi-jwt-auth) - JWT authorization with a rich feature (based on [Flask-JWT-Extended](https://github.com/vimalloc/flask-jwt-extended))
 
 ### Databases
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [FastAPI Security](https://github.com/jmagnusson/fastapi-security) - Implements authentication and authorization as dependencies in FastAPI.
 - [FastAPI Simple Security](https://github.com/mrtolkien/fastapi_simple_security) - Out-of-the-box API key security manageable through path operations.
 - [FastAPI Users](https://github.com/frankie567/fastapi-users) - Account management, authentication, authorization.
+- [FastAPI JWT Auth](https://github.com/IndominusByte/fastapi-jwt-auth) - JWT authorization with a rich feature (based on [Flask-JWT-Extended](https://github.com/vimalloc/flask-jwt-extended))
 
 ### Databases
 


### PR DESCRIPTION
When I migrate from flask to FastAPI it's hard to find a package that has a feature like flask-jwt-extended so I decide to make one. Here is the link to the docs https://indominusbyte.github.io/fastapi-jwt-auth. I think it might be interesting to add in here 😁