### PR TITLE
add ormar async orm

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 - [GINO](https://github.com/python-gino/gino) - A lightweight asynchronous ORM built on top of SQLAlchemy core for Python asyncio.
   - [FastAPI Example](https://github.com/leosussan/fastapi-gino-arq-uvicorn)
 - [ORM](https://github.com/encode/orm) - An async ORM.
-- [ormar](https://collerek.github.io/ormar/fastapi/) - The ormar package is an async mini ORM for Python, with support for Postgres, MySQL, and SQLite.
+- [ormar](https://collerek.github.io/ormar/fastapi/) - An async mini ORM for Python.
 
 
 #### Query Builders

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@
 - [GINO](https://github.com/python-gino/gino) - A lightweight asynchronous ORM built on top of SQLAlchemy core for Python asyncio.
   - [FastAPI Example](https://github.com/leosussan/fastapi-gino-arq-uvicorn)
 - [ORM](https://github.com/encode/orm) - An async ORM.
+- [ormar](https://collerek.github.io/ormar/fastapi/) - The ormar package is an async mini ORM for Python, with support for Postgres, MySQL, and SQLite.
+
 
 #### Query Builders
 


### PR DESCRIPTION
Main benefits of using ormar:
* getting an async ORM that can be used with async frameworks (fastapi, starlette etc.)
* getting just one model to maintain - you don't have to maintain pydantic and other orm model (sqlalchemy, peewee, gino etc.)

Added by me:
* Django orm like syntax (subjective selling point but I liked)

The project is still young but well mantained.