### PR TITLE
📦 NEW: Adding Deta to Iaas

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 - [Google Compute Engine](https://cloud.google.com/compute/)
 - [Digital Ocean](https://www.digitalocean.com/)
 - [Linode](https://www.linode.com/)
+- [Deta](https://www.deta.sh/)
 
 ### Serverless
 


### PR DESCRIPTION
Adding Deta to the Iaas list. Deta is actually [sponsoring](https://twitter.com/tiangolo/status/1324759348275499009) FastAPI and is FastAPI focused due to all of their Python docs are based on FastAPI deploys. So much so they install FastAPI by default when python's detected and FastAPI is in a `requests.txt` file. 