### PR TITLE
feat: check expired links

### DIFF
--- a/.github/workflows/expired-links.yml
+++ b/.github/workflows/expired-links.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  pull_request:
   schedule:
   # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
   - cron: "0 9 * * *"

--- a/.github/workflows/expired-links.yml
+++ b/.github/workflows/expired-links.yml
@@ -6,8 +6,8 @@ on:
     - master
   pull_request:
   schedule:
-  # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-  - cron: "0 9 * * *"
+  # Run every first day at 00:00 AM every month.
+  - cron: "0 0 1 * *"
 
 jobs:
   markdown-link-check:
@@ -15,3 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'

--- a/.github/workflows/expired-links.yml
+++ b/.github/workflows/expired-links.yml
@@ -1,0 +1,16 @@
+name: Check Markdown links
+
+on:
+  push:
+    branches:
+    - master
+  schedule:
+  # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
+  - cron: "0 9 * * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/expired-links.yml
+++ b/.github/workflows/expired-links.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-  pull_request:
   schedule:
   # Run every first day at 00:00 AM every month.
   - cron: "0 0 1 * *"

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www.linode.com/"
+    }
+  ]
+}


### PR DESCRIPTION
Add Github action to detect expired links. It's schedule to run once a month.

Checklist:
- [X] Add `markdown-link-check` github action
- [X] Ignore [linode](https://www.linode.com/) URL (a 403 is detected).

Reference: https://github.com/gaurav-nelson/github-action-markdown-link-check