### PR TITLE
Added fastapi_crudrouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 
 - [FastAPI Cache](https://github.com/comeuplater/fastapi_cache) - A simple lightweight cache system.
 - [FastAPI Contrib](https://github.com/identixone/fastapi_contrib) - Opinionated set of utilities: pagination, auth middleware, permissions, custom exception handlers, MongoDB support, and Opentracing middleware.
+- [FastAPI CRUDROuter](https://github.com/awtkns/fastapi-crudrouter) - An FastAPI router that automatically creates and documents CRUD routes for your models.
 - [FastAPI Plugins](https://github.com/madkote/fastapi-plugins) - Redis and Scheduler plugins.
 - [FastAPI ServiceUtils](https://github.com/skallfass/fastapi_serviceutils) - Generator for creating API services.
 - [FastAPI SocketIO](https://github.com/pyropy/fastapi-socketio) - Easy integration for FastAPI and SocketIO.
@@ -105,6 +106,7 @@
 - [Starlette Prometheus](https://github.com/perdy/starlette-prometheus) - Prometheus integration for FastAPI and Starlette.
 - [Starlette Exporter](https://github.com/stephenhillier/starlette_exporter) - One more prometheus integration for FastAPI and Starlette.
 - [Starlette-OpenTracing](https://github.com/acidjunk/starlette-opentracing) - Opentracing support for Starlette and FastAPI.
+
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 
 - [FastAPI Cache](https://github.com/comeuplater/fastapi_cache) - A simple lightweight cache system.
 - [FastAPI Contrib](https://github.com/identixone/fastapi_contrib) - Opinionated set of utilities: pagination, auth middleware, permissions, custom exception handlers, MongoDB support, and Opentracing middleware.
-- [FastAPI CRUDROuter](https://github.com/awtkns/fastapi-crudrouter) - An FastAPI router that automatically creates and documents CRUD routes for your models.
+- [FastAPI CRUDROuter](https://github.com/awtkns/fastapi-crudrouter) - A FastAPI router that automatically creates and documents CRUD routes for your models.
 - [FastAPI Plugins](https://github.com/madkote/fastapi-plugins) - Redis and Scheduler plugins.
 - [FastAPI ServiceUtils](https://github.com/skallfass/fastapi_serviceutils) - Generator for creating API services.
 - [FastAPI SocketIO](https://github.com/pyropy/fastapi-socketio) - Easy integration for FastAPI and SocketIO.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@
 - [Starlette Exporter](https://github.com/stephenhillier/starlette_exporter) - One more prometheus integration for FastAPI and Starlette.
 - [Starlette-OpenTracing](https://github.com/acidjunk/starlette-opentracing) - Opentracing support for Starlette and FastAPI.
 
-
 ## Resources
 
 ### Official Resources


### PR DESCRIPTION
### Added **[fastapi-crudrouter](https://fastapi-crudrouter.awtkns.com/)** to the list of  fastapi utilities. :sparkles:

Fastapi-crudrouter is a package that extends the built in fastapi [APIRouter](https://fastapi.tiangolo.com/tutorial/bigger-applications/?h=+api+rout#apirouter) to automatically generate and document CRUD based pydantic your models. 

Below is a simple example of what the CRUDRouter can do. In just ten lines of code, you can generate all the crud routes you need for any model.
```python
from pydantic import BaseModel
from fastapi import FastAPI
from fastapi_crudrouter import MemoryCRUDRouter as CRUDRouter

class Potato(BaseModel):
    id: int
    color: str
    mass: float

app = FastAPI()
app.include_router(CRUDRouter(schema=Potato))
```

The goal of this package is to be useful for rapid prototyping, small projects and hackathons.  Currently it supports both async and non-async relational databases with future plans for non-relational databases

--- 

**Documentation**: <a href="https://fastapi-crudrouter.awtkns.com" target="_blank">https://fastapi-crudrouter.awtkns.com</a>
**Source Code**: <a href="https://github.com/awtkns/fastapi-crudrouter" target="_blank">https://github.com/awtkns/fastapi-crudrouter</a>
**Disclaimer:** I am the author of the package
