### PR TITLE
Add property-based testing tutorial for FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [Porting Flask to FastAPI for ML Model Serving](https://www.pluralsight.com/tech-blog/porting-flask-to-fastapi-for-ml-model-serving/) - Comparison of Flask vs FastAPI.
 - [Real-time data streaming using FastAPI and WebSockets](https://stribny.name/blog/2020/07/real-time-data-streaming-using-fastapi-and-websockets/) - Learn how to stream data from FastAPI directly into a real-time chart.
 - [Serving Machine Learning Models with FastAPI in Python](https://medium.com/@8B_EC/tutorial-serving-machine-learning-models-with-fastapi-in-python-c1a27319c459) - Use FastAPI to quickly and easily deploy and serve machine learning models in Python as a RESTful API.
+- [Using Hypothesis and Schemathesis to Test FastAPI](https://testdriven.io/blog/fastapi-hypothesis/) - Apply property-based testing to FastAPI.
 
 ### Talks
 


### PR DESCRIPTION
Hi! Thank you for maintaining this list!

This PR adds a link to the "Using Hypothesis and Schemathesis to Test FastAPI" tutorial by @amalshaji. It explains how easily FastAPI apps can be tested with property-based testing tools. For example, with Schemathesis, the simplest test is just running a single command in the shell - all test cases will be automatically generated, and explicit examples will be checked as well.