### PR TITLE
Add Beanie

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@
 
 #### ODMs
 
+- [Beanie](https://github.com/roman-right/beanie) - Asynchronous Python ODM for MongoDB, based on [Motor](https://motor.readthedocs.io/en/stable/)
+and [Pydantic](https://pydantic-docs.helpmanual.io/), which supports data and schema migrations out of the box.
 - [MongoEngine](http://mongoengine.org/) - A Document-Object Mapper (think ORM, but for document databases) for working with MongoDB from Python.
 - [Motor](https://motor.readthedocs.io/) - Asynchronous Python driver for MongoDB.
 - [ODMantic](https://art049.github.io/odmantic/) - AsyncIO MongoDB ODM integrated with [Pydantic](https://pydantic-docs.helpmanual.io/). 
-- [Beanie](https://github.com/roman-right/beanie) - Asynchronous Python ODM for MongoDB, based on [Motor](https://motor.readthedocs.io/en/stable/)
-and [Pydantic](https://pydantic-docs.helpmanual.io/). Beanie supports data and schema migrations out of the box.
 
 #### Other Tools
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@
 - [MongoEngine](http://mongoengine.org/) - A Document-Object Mapper (think ORM, but for document databases) for working with MongoDB from Python.
 - [Motor](https://motor.readthedocs.io/) - Asynchronous Python driver for MongoDB.
 - [ODMantic](https://art049.github.io/odmantic/) - AsyncIO MongoDB ODM integrated with [Pydantic](https://pydantic-docs.helpmanual.io/). 
+- [Beanie](https://github.com/roman-right/beanie) - Asynchronous Python ODM for MongoDB, based on [Motor](https://motor.readthedocs.io/en/stable/)
+and [Pydantic](https://pydantic-docs.helpmanual.io/). Beanie supports data and schema migrations out of the box.
 
 #### Other Tools
 


### PR DESCRIPTION
Hi,

Beanie is an Asynchronous Python ODM for MongoDB. It is based on Pydantic, that's why it is perfectly suited to the FastAPI.

The documentation could be found here - https://roman-right.github.io/beanie/

Also, there are some articles about Beanie, where it is used together with FastAPI:
- In MongoDB developer blog - https://developer.mongodb.com/article/beanie-odm-fastapi-cocktails/
- Mine from dev.to - https://dev.to/romanright/announcing-beanie-mongodb-odm-56e

I think this fits well to be listed here :smiley: 