### PR TITLE
Add Ganimede

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ and [Pydantic](https://pydantic-docs.helpmanual.io/), which supports data and sc
 - [Jupyter Notebook REST API](https://github.com/Invictify/Jupter-Notebook-REST-API) - Run your Jupyter notebooks as RESTful API endpoints.
 - [Manage FastAPI](https://github.com/ycd/manage-fastapi) - CLI tool for generating and managing FastAPI projects.
 - [msgpack-asgi](https://github.com/florimondmanca/msgpack-asgi) - Automatic [MessagePack](https://msgpack.org/) content negotiation.
+- [Ganimede](https://github.com/manugraj/ganimede) - A developer/production storage and safe-execution environment to store, version, edit, upgrade and integrate Jupyter notebooks.
 
 ### Email
 


### PR DESCRIPTION
Ganimede is a tool to manage jupyter notebook as a direct coded interface. We can deploy a jupyter notebook, along with a project definition. We can test and update the jupyter in a sandbox environment. We can upgrade to next version of notebook by upgrading from an edited version. It solves the pain of versioning jupyter notebook and its changes as well as it makes it easy to directly integrate it to other systems of product as a microservice.