### PR TITLE
Add pydantic-i18n package

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ and [Pydantic](https://pydantic-docs.helpmanual.io/), which supports data and sc
 - [Starlette Exporter](https://github.com/stephenhillier/starlette_exporter) - One more prometheus integration for FastAPI and Starlette.
 - [Starlette OpenTracing](https://github.com/acidjunk/starlette-opentracing) - Opentracing support for Starlette and FastAPI.
 - [Starlette Prometheus](https://github.com/perdy/starlette-prometheus) - Prometheus integration for FastAPI and Starlette.
+- [pydantic-i18n](https://github.com/boardpack/pydantic-i18n) - an extension to support an i18n for the pydantic error messages.
 
 ## Resources
 


### PR DESCRIPTION
Hello, pydantic-i18n can be useful for FastAPI users, so, I think, it makes sense to add it to your list :slightly_smiling_face:

P.S. Any feedback is welcome, thanks! :slightly_smiling_face: