### PR TITLE
Add FastAPI-Template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Compute:
 - [FastAPI and React Template](https://github.com/Buuntu/fastapi-react) - Full stack cookiecutter boilerplate using FastAPI, TypeScript, Docker, PostgreSQL, and React.
 - [FastAPI Nano](https://github.com/rednafi/fastapi-nano) - Simple FastAPI template with factory pattern architecture.
 - [inboard](https://github.com/br3ndonland/inboard) - Docker images to power your FastAPI apps and help you ship faster.
+- [FastAPI template](https://github.com/s3rius/FastAPI-template) - Flexible lightweight FastAPI project generator. It includes newest SQLAlchemy version, multiple databases support, CI\CD, docker and kubernetes integrations.
 
 ### Open Source Projects
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Compute:
 - [FastAPI and React Template](https://github.com/Buuntu/fastapi-react) - Full stack cookiecutter boilerplate using FastAPI, TypeScript, Docker, PostgreSQL, and React.
 - [FastAPI Nano](https://github.com/rednafi/fastapi-nano) - Simple FastAPI template with factory pattern architecture.
 - [inboard](https://github.com/br3ndonland/inboard) - Docker images to power your FastAPI apps and help you ship faster.
-- [FastAPI template](https://github.com/s3rius/FastAPI-template) - Flexible lightweight FastAPI project generator. It includes newest SQLAlchemy version, multiple databases support, CI\CD, docker and kubernetes integrations.
+- [FastAPI template](https://github.com/s3rius/FastAPI-template) - Flexible lightweight FastAPI project generator. It includes the newest SQLAlchemy version, multiple databases support, CI\CD, docker and kubernetes integrations.
 
 ### Open Source Projects
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Compute:
 - [FastAPI and React Template](https://github.com/Buuntu/fastapi-react) - Full stack cookiecutter boilerplate using FastAPI, TypeScript, Docker, PostgreSQL, and React.
 - [FastAPI Nano](https://github.com/rednafi/fastapi-nano) - Simple FastAPI template with factory pattern architecture.
 - [inboard](https://github.com/br3ndonland/inboard) - Docker images to power your FastAPI apps and help you ship faster.
-- [FastAPI template](https://github.com/s3rius/FastAPI-template) - Flexible lightweight FastAPI project generator. It includes the newest SQLAlchemy version, multiple databases support, CI\CD, docker and kubernetes integrations.
+- [FastAPI template](https://github.com/s3rius/FastAPI-template) - Flexible, lightweight FastAPI project generator. It includes support for SQLAlchemy, multiple databases, CI/CD, Docker, and Kubernetes.
 
 ### Open Source Projects
 


### PR DESCRIPTION
FastAPI-Template is a robust template with many usable features. 
It's really lightweight and has many useful integrations, such as gitlab-ci, github actions, kubernetes, docker-compose and cutting edge async SQLAlchemy orm.   

Signed-off-by: Pavel Kirilin <win10@list.ru>