### PR TITLE
Removing zappa from serverless list

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ Frameworks:
 - [Chalice](https://github.com/aws/chalice)
 - [Mangum](https://mangum.io/) - Adapter for running ASGI applications with AWS Lambda and API Gateway.
 - [Vercel](https://vercel.com/) - (formerly Zeit) ([example](https://github.com/paul121/fastapi-zeit-now)).
-- [Zappa](https://github.com/Miserlou/Zappa)
 
 Compute:
 


### PR DESCRIPTION
It does not support FastAPI or ASGI in general.
See
https://github.com/zappa/Zappa/issues/759
https://github.com/zappa/Zappa/issues/898