### PR TITLE
Add cookiecutter-fastapi-async

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Compute:
 - [FastAPI Model Server Skeleton](https://github.com/eightBEC/fastapi-ml-skeleton) - Skeleton app to serve machine learning models production-ready.
 - [cookiecutter-spacy-fastapi](https://github.com/microsoft/cookiecutter-spacy-fastapi) - Quick deployments of spaCy models with FastAPI.
 - [cookiecutter-fastapi](https://github.com/arthurhenrique/cookiecutter-fastapi) - Cookiecutter template for FastAPI projects using: Machine Learning, Poetry, Azure Pipelines and pytest.
+- [cookiecutter-fastapi-async](https://github.com/anancarv/cookiecutter-fastapi-async) - Cookiecutter template for creating a backend using FastAPI & SQLAlchemy Async ORM
 - [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) - Generate modern FastAPI Python clients (via FastAPI) from OpenAPI.
 - [Pywork](https://github.com/vutran1710/YeomanPywork) - [Yeoman](https://yeoman.io/) generator to scaffold a FastAPI app.
 - [uvicorn-gunicorn-fastapi-docker](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker) - Docker image with Uvicorn managed by Gunicorn for high-performance FastAPI web applications in Python 3.7 and 3.6 with performance auto-tuning.


### PR DESCRIPTION
Hi ! [cookiecutter-fastapi-async](https://github.com/anancarv/cookiecutter-fastapi-async) is a template for creating a simple backend using FastAPI & SQLAlchemy Async ORM.