### PR TITLE
Add `FastAPI Control` - Utility to implement class-based routing with dependency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 - [FastAPI Cache](https://github.com/long2ice/fastapi-cache) - A tool to cache FastAPI response and function results, with support for Redis, Memcached, DynamoDB, and in-memory backends.
 - [FastAPI Chameleon](https://github.com/mikeckennedy/fastapi-chameleon) - Adds integration of the Chameleon template language to FastAPI.
 - [FastAPI Contrib](https://github.com/identixone/fastapi_contrib) - Opinionated set of utilities: pagination, auth middleware, permissions, custom exception handlers, MongoDB support, and Opentracing middleware.
+- [FastAPI Control](https://github.com/leynier/fastapi-control) - FastAPI utility to implement class-based routing with controllers and dependency injection.
 - [FastAPI CRUDRouter](https://github.com/awtkns/fastapi-crudrouter) - A FastAPI router that automatically creates and documents CRUD routes for your models.
 - [FastAPI Events](https://github.com/melvinkcx/fastapi-events) - Asynchronous event dispatching/handling library for FastAPI and Starlette.
 - [FastAPI FeatureFlags](https://github.com/Pytlicek/fastapi-featureflags) - Simple implementation of feature flags for FastAPI.


### PR DESCRIPTION
This is useful because the closest alternative is FastAPI-Utils class-based routing but with automatic dependency injection.