### PR TITLE
docs: add fastapi-sqla to ORM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 #### ORMs
 
 - [FastAPI SQLAlchemy](https://github.com/mfreeborn/fastapi-sqlalchemy) - Simple integration between FastAPI and [SQLAlchemy](https://www.sqlalchemy.org/).
+- [Fastapi-SQLA](https://github.com/dialoguemd/fastapi-sqla) - SQLAlchemy extension for FastAPI with support for pagination, asyncio and pytest, ready for production.
 - [FastAPIwee](https://github.com/Ignisor/FastAPIwee) - A simple way to create REST API based on [PeeWee](https://github.com/coleifer/peewee) models.
 - [GINO](https://github.com/python-gino/gino) - A lightweight asynchronous ORM built on top of SQLAlchemy core for Python asyncio.
   - [FastAPI Example](https://github.com/leosussan/fastapi-gino-arq-uvicorn)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 #### ORMs
 
 - [FastAPI SQLAlchemy](https://github.com/mfreeborn/fastapi-sqlalchemy) - Simple integration between FastAPI and [SQLAlchemy](https://www.sqlalchemy.org/).
-- [Fastapi-SQLA](https://github.com/dialoguemd/fastapi-sqla) - SQLAlchemy extension for FastAPI with support for pagination, asyncio and pytest, ready for production.
+- [Fastapi-SQLA](https://github.com/dialoguemd/fastapi-sqla) - SQLAlchemy extension for FastAPI with support for pagination, asyncio, and pytest.
 - [FastAPIwee](https://github.com/Ignisor/FastAPIwee) - A simple way to create REST API based on [PeeWee](https://github.com/coleifer/peewee) models.
 - [GINO](https://github.com/python-gino/gino) - A lightweight asynchronous ORM built on top of SQLAlchemy core for Python asyncio.
   - [FastAPI Example](https://github.com/leosussan/fastapi-gino-arq-uvicorn)


### PR DESCRIPTION
Added [Fastapi-SQLA](https://github.com/dialoguemd/fastapi-sqla) to the list in the ORM section in alphabetical order.

## Why is it awesome?

1. It support latest SQLAlchemy development and best practices: [asyncio support](https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html), [2.0 syntax](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html), [session guidelines](https://docs.sqlalchemy.org/en/14/orm/session_basics.html#when-do-i-construct-a-session-when-do-i-commit-it-and-when-do-i-close-it);
2. It provides pagination support out-of-the box;
3. It provides pytest fixtures;
4. It uses Fastapi dependency injection & starlette middleware;
5. It is carefully maintained and the team is super responsive and diligent whenever someone opens an issue;
