### PR TITLE
FastStream added

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 - [Pydantic-SQLAlchemy](https://github.com/tiangolo/pydantic-sqlalchemy) - Convert SQLAlchemy models to [Pydantic](https://docs.pydantic.dev/latest/) models.
 - [FastAPI-CamelCase](https://nf1s.github.io/fastapi-camelcase/) - CamelCase JSON support for FastAPI utilizing [Pydantic](https://docs.pydantic.dev/latest/).
   - [CamelCase Models with FastAPI and Pydantic](https://medium.com/analytics-vidhya/camel-case-models-with-fast-api-and-pydantic-5a8acb6c0eee) - Accompanying blog post from the author of the extension.
+- [FastStream](https://github.com/airtai/faststream) - FastStream simplifies the process of writing producers and consumers for message queues, handling all the parsing, networking and documentation generation automatically. It supports multiple brokers such as ApacheKafka and RabbitMQ. Integrates with any HTTP server including FastAPI.
 
 ### Developer Tools
 


### PR DESCRIPTION
FastStream is our library for writing services consuming and producing messages from streaming protocols such as ApacheKafka and RabbitMQ. Integrates well with FastAPI.