### PR TITLE
add Polar to the open source projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Compute:
 - [Markdown-Videos](https://github.com/Snailedlt/Markdown-Videos) - API for generating thumbnails to embed into your markdown content.
 - [Nemo](https://github.com/harshitsinghai77/nemo-backend) - Be productive with Nemo.
 - [OPAL (Open Policy Administration Layer)](https://github.com/authorizon/opal) - Real-time authorization updates on top of Open-Policy; built with FastAPI, Typer, and FastAPI WebSocket pub/sub.
+- [Polar](https://github.com/polarsource/polar) - A funding and monetization platform for developers, built with Fast API, SQL Alchemy, Alembic and Arq.
 - [RealWorld Example App - mongo](https://github.com/markqiu/fastapi-mongodb-realworld-example-app)
 - [RealWorld Example App - postgres](https://github.com/nsidnev/fastapi-realworld-example-app)
 - [redis-streams-fastapi-chat](https://github.com/leonh/redis-streams-fastapi-chat) - A simple Redis Streams backed chat app using Websockets, Asyncio and FastAPI/Starlette.

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Compute:
 - [Markdown-Videos](https://github.com/Snailedlt/Markdown-Videos) - API for generating thumbnails to embed into your markdown content.
 - [Nemo](https://github.com/harshitsinghai77/nemo-backend) - Be productive with Nemo.
 - [OPAL (Open Policy Administration Layer)](https://github.com/authorizon/opal) - Real-time authorization updates on top of Open-Policy; built with FastAPI, Typer, and FastAPI WebSocket pub/sub.
-- [Polar](https://github.com/polarsource/polar) - A funding and monetization platform for developers, built with Fast API, SQL Alchemy, Alembic and Arq.
+- [Polar](https://github.com/polarsource/polar) - A funding and monetization platform for developers, built with FastAPI, SQLAlchemy, Alembic, and Arq.
 - [RealWorld Example App - mongo](https://github.com/markqiu/fastapi-mongodb-realworld-example-app)
 - [RealWorld Example App - postgres](https://github.com/nsidnev/fastapi-realworld-example-app)
 - [redis-streams-fastapi-chat](https://github.com/leonh/redis-streams-fastapi-chat) - A simple Redis Streams backed chat app using Websockets, Asyncio and FastAPI/Starlette.


### PR DESCRIPTION
# Motivation

I think the project belongs in this repo because:

- It is one of a very few somewhat large-scale open source projects that uses Fast API.
- For people who want to see how actual, real-world Fast API apps are structured, what patterns they use and how things are done commercially, in environments where the framework is being used for commercial purposes, it's an invaluable learning resource.
- Despite being the codebase for a for-profit company, the project is Apache licensed, which allows developers to reuse code fragments in their own apps.

