### PR TITLE
Add fastapi-injectable to utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 - [FastAPI CRUDRouter](https://github.com/awtkns/fastapi-crudrouter) - A FastAPI router that automatically creates and documents CRUD routes for your models.
 - [FastAPI Events](https://github.com/melvinkcx/fastapi-events) - Asynchronous event dispatching/handling library for FastAPI and Starlette.
 - [FastAPI FeatureFlags](https://github.com/Pytlicek/fastapi-featureflags) - Simple implementation of feature flags for FastAPI.
+- [FastAPI Injectable](https://github.com/JasperSui/fastapi-injectable) - Use FastAPI's dependency injection outside route handlers in CLI tools, background tasks, workers, and more.
 - [FastAPI Jinja](https://github.com/AGeekInside/fastapi-jinja) - Adds integration of the Jinja template language to FastAPI.
 - [FastAPI Lazy](https://github.com/yezz123/fastango) - Lazy package to start your project using FastAPI.
 - [FastAPI Limiter](https://github.com/long2ice/fastapi-limiter) - A request rate limiter for FastAPI.


### PR DESCRIPTION
Hi mjhea0,

[fastapi-injectable](https://github.com/JasperSui/fastapi-injectable) is a production-ready package for FastAPI developers who need to use dependency injection outside of HTTP routes, which solves the problem that exists in FastAPI ecosystem for a long time.

Basic example here:

```python
from typing import Annotated

from fastapi import Depends
from fastapi_injectable import injectable

class Database:
    def query(self) -> str:
        return "data"

def get_db() -> Database:
    return Database()

@injectable
def process_data(db: Annotated[Database, Depends(get_db)]) -> str:
    return db.query()

# Use it anywhere!
result = process_data()
print(result) # Output: 'data'
```

Here's the related issue and discussion:
- Issue: https://github.com/fastapi/fastapi/issues/1105
- Discussion: https://github.com/fastapi/fastapi/discussions/7720

I understand that you said:
> I tend to only add projects that are at least a year old and are consistently being updated.

But I genuinely think [fastapi-injectable](https://github.com/JasperSui/fastapi-injectable) will help lots of devs if this can be put on the list as soon as possible, but this is your project, so the decision is ultimately yours to make.

Anyways, thanks for this "awesome" repository!