### PR TITLE
Add FastAPI to MCP auto generator tool to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 - [Jupyter Notebook REST API](https://github.com/Invictify/Jupter-Notebook-REST-API) - Run your Jupyter notebooks as RESTful API endpoints.
 - [Manage FastAPI](https://github.com/ycd/manage-fastapi) - CLI tool for generating and managing FastAPI projects.
 - [msgpack-asgi](https://github.com/florimondmanca/msgpack-asgi) - Automatic [MessagePack](https://msgpack.org/) content negotiation.
+- [FastAPI to MCP auto generator](https://github.com/tadata-org/fastapi_mcp) - A zero-configuration tool for automatically exposing FastAPI endpoints as MCP tools by [Tadata](https://tadata.com/).
 
 ### Email
 


### PR DESCRIPTION
This repository is a FastAPI to MCP auto-generator, designed for effortless conversion of your APIs into MCP tools. With zero configuration required, you can instantly leverage your FastAPI endpoints within Cursor as MCPs become a standard for AI interaction.