### PR TITLE
Add Wireup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Admin](#admin)
   - [Auth](#auth)
   - [Databases](#databases)
+  - [Dependency Injection](#dependency-injection)
   - [Developer Tools](#developer-tools)
   - [Email](#email)
   - [Utils](#utils)
@@ -102,6 +103,9 @@
 - [Pydantic-SQLAlchemy](https://github.com/tiangolo/pydantic-sqlalchemy) - Convert SQLAlchemy models to [Pydantic](https://docs.pydantic.dev/latest/) models.
 - [FastAPI-CamelCase](https://nf1s.github.io/fastapi-camelcase/) - CamelCase JSON support for FastAPI utilizing [Pydantic](https://docs.pydantic.dev/latest/).
   - [CamelCase Models with FastAPI and Pydantic](https://medium.com/analytics-vidhya/camel-case-models-with-fast-api-and-pydantic-5a8acb6c0eee) - Accompanying blog post from the author of the extension.
+ 
+### Dependency Injection
+- [Wireup](https://github.com/maldoinc/wireup) - Inject dependencies with zero runtime overhead in FastAPI; Share dependencies across web, cli or other interfaces.
 
 ### Developer Tools
 


### PR DESCRIPTION
Adds [Wireup](https://github.com/maldoinc/wireup). This is an alternative DI framework with integration for fastapi that enables injecting dependencies with zero runtime overhead for most use cases and lets you share dependencies across http, cli or other interfaces. 

---

Added a new section since it didn't quite fit elsewhere but do let me know if you'd like me to move it elsewhere.