### PR TITLE
docs: add FastSQLA to ORM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [FastAPI SQLAlchemy](https://github.com/mfreeborn/fastapi-sqlalchemy) - Simple integration between FastAPI and [SQLAlchemy](https://www.sqlalchemy.org/).
 - [Fastapi-SQLA](https://github.com/dialoguemd/fastapi-sqla) - SQLAlchemy extension for FastAPI with support for pagination, asyncio, and pytest.
 - [FastAPIwee](https://github.com/Ignisor/FastAPIwee) - A simple way to create REST API based on [PeeWee](https://github.com/coleifer/peewee) models.
+- [FastSQLA](https://github.com/hadrien/FastSQLA) - Async SQLAlchemy 2.0+ extension for FastAPI with SQLModel support, built-in pagination & more.
 - [GINO](https://github.com/python-gino/gino) - A lightweight asynchronous ORM built on top of SQLAlchemy core for Python asyncio.
   - [FastAPI Example](https://github.com/leosussan/fastapi-gino-arq-uvicorn)
 - [ORM](https://github.com/encode/orm) - An async ORM.


### PR DESCRIPTION
Added [FastSQLA](https://github.com/hadrien/FastSQLA) to the list in the ORM section in alphabetical order.

# Why is it awesome?

1. It support latest SQLAlchemy>=2.0 development and best practices: asyncio support, 2.0 syntax, session guidelines;
2. It provides pagination support out-of-the box;
3. It uses latest Fastapi dependency injection;
4. It is carefully maintained and the team is super responsive and diligent whenever someone opens an issue;
5. It is solidly documented -> https://hadrien.github.io/FastSQLA/