### PR TITLE
Add Axioms FastAPI to authentication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 ### Auth
 
 - [AuthX](https://github.com/yezz123/AuthX) - Customizable Authentications and Oauth2 management for FastAPI.
+- [Axioms FastAPI](https://github.com/abhishektiwari/axioms-fastapi) - OAuth2/OIDC authentication and authorization for FastAPI. Supports authentication and claim-based fine-grained authorization (scopes, roles, permissions) using JWT tokens.
 - [FastAPI Auth](https://github.com/dmontagu/fastapi-auth) - Pluggable auth that supports the OAuth2 Password Flow with JWT access and refresh tokens.
 - [FastAPI Azure Auth](https://github.com/Intility/fastapi-azure-auth) - Azure AD authentication for your APIs with single and multi tenant support.
 - [FastAPI Cloud Auth](https://github.com/tokusumi/fastapi-cloudauth) - Simple integration between FastAPI and cloud authentication services (AWS Cognito, Auth0, Firebase Authentication).


### PR DESCRIPTION
Added Axioms FastAPI for OAuth2/OIDC support.

[Axioms FastAPI](https://github.com/abhishektiwari/axioms-fastapi) supports OAuth2/OIDC authentication and authorization for FastAPI APIs. Supports authentication and claim-based fine-grained authorization (scopes, roles, permissions) using JWT tokens.

Works with access tokens issued by various authorization servers including [AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html), [Auth0](https://auth0.com/docs/secure/tokens/access-tokens/access-token-profiles), [Okta](https://developer.okta.com/docs/api/oauth2/), [Microsoft Entra](https://learn.microsoft.com/en-us/security/zero-trust/develop/configure-tokens-group-claims-app-roles), etc.