### PR TITLE
Add fastapi-websocket-stabilizer to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@
 - [FastAPI Utilities](https://github.com/fastapiutils/fastapi-utils) - Reusable utilities: class-based views, response inferring router, periodic tasks, timing middleware, SQLAlchemy session, OpenAPI spec simplification.
 - [FastAPI Websocket Pub/Sub](https://github.com/authorizon/fastapi_websocket_pubsub) - The classic pub/sub pattern made easily accessible and scalable over the web and across your cloud in realtime.
 - [FastAPI Websocket RPC](https://github.com/authorizon/fastapi_websocket_rpc) - RPC (bidirectional JSON RPC) over Websockets made easy, robust, and production ready.
+- [FastAPI Websocket Stabilizer](https://github.com/yuuichieguchi/fastapi-websocket-stabilizer) - Production-ready WebSocket connection management with automatic heartbeat, graceful shutdown, and reconnection support.
 - [OpenTelemetry FastAPI Instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi) - Library provides automatic and manual instrumentation of FastAPI web frameworks, instrumenting http requests served by applications utilizing the framework.
 - [Prerender Python Starlette](https://github.com/BeeMyDesk/prerender-python-starlette) - Starlette middleware for Prerender.
 - [Prometheus FastAPI Instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator) - A configurable and modular Prometheus Instrumentator for your FastAPI application.


### PR DESCRIPTION
Hi team,

I would like to introduce fastapi-websocket-stabilizer.

fastapi-websocket-stabilizer provides production-ready WebSocket connection management for FastAPI:

Automatic heartbeat/ping-pong detection
Graceful shutdown handling
Reconnection token support
Zero dependencies beyond FastAPI
PyPI: https://pypi.org/project/fastapi-websocket-stabilizer/

Thank you.