### PR TITLE
Add FastAPI PraisonAI to Utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [FastAPI MQTT](https://github.com/sabuhish/fastapi-mqtt) - An extension for the MQTT protocol.
 - [FastAPI Opentracing](https://github.com/wesdu/fastapi-opentracing) - Opentracing middleware and database tracing support for FastAPI.
 - [FastAPI Pagination](https://github.com/uriyyo/fastapi-pagination) - Pagination for FastAPI.
+- [FastAPI PraisonAI](https://github.com/MervinPraison/fastapi-praisonai) - Integration for PraisonAI multi-agent workflows with FastAPI router and async client.
 - [FastAPI Plugins](https://github.com/madkote/fastapi-plugins) - Redis and Scheduler plugins.
 - [FastAPI ServiceUtils](https://github.com/skallfass/fastapi_serviceutils) - Generator for creating API services.
 - [FastAPI SocketIO](https://github.com/pyropy/fastapi-socketio) - Easy integration for FastAPI and SocketIO.


### PR DESCRIPTION
Adds [FastAPI PraisonAI](https://github.com/MervinPraison/fastapi-praisonai) to the Utils section.

**What it does:**
- Provides a FastAPI router for integrating with PraisonAI multi-agent workflows
- Includes async client for API calls
- Published on PyPI: https://pypi.org/project/fastapi-praisonai/

**Placement:** Utils section, alphabetically ordered between FastAPI Pagination and FastAPI Plugins.