### PR TITLE
feat: Add Vedika API - REST API for FastAPI with async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@
 - [Starlette Prometheus](https://github.com/perdy/starlette-prometheus) - Prometheus integration for FastAPI and Starlette.
 - [Strawberry GraphQL](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses.
 
+## External APIs
+
+- [Vedika](https://vedika.io) - REST API for FastAPI - Vedic astrology calculations with AI chatbot. 108+ endpoints, 22 languages, 97% accuracy. Python/JavaScript SDKs with async support.
+
 ## Resources
 
 ### Official Resources


### PR DESCRIPTION
## Why this is awesome

[Vedika](https://vedika.io) is a REST API for FastAPI developers building Vedic astrology applications. It provides:

- **108+ endpoints** for Vedic astrology calculations (kundali, horoscope, panchang, dasha, dosha, matching, numerology, transits, gemstones, muhurta, and more)
- **22 languages** support with async-compatible responses
- **97% accuracy** using in-house Swiss Ephemeris calculators
- **AI chatbot** with 6 specialized agents using swarm intelligence
- **Python SDK** with async/await support for FastAPI integration
- **JavaScript SDK** for frontend frameworks
- **Sandbox mode** for development (free, no API key needed)

This aligns with FastAPI's async-first architecture and provides domain-specific APIs that FastAPI developers can integrate. The API follows RESTful patterns and returns JSON responses compatible with Pydantic models.

Added a new "External APIs" section after Utils to list external services that FastAPI developers may find useful, similar to how other awesome lists include external resources.