### PR TITLE
Add What Broke Today to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Compute:
 - [Slackers](https://github.com/uhavin/slackers) - Slack webhooks API.
 - [TermPair](https://github.com/cs01/termpair) - View and control terminals from your browser with end-to-end encryption.
 - [Universities](https://github.com/ycd/universities) - API service for obtaining information about +9600 universities worldwide.
+- [What Broke Today](https://whatbroke.today/) - AI-powered outage aggregator tracking 100+ cloud services, built with FastAPI. Features Telegram alerts, RSS feed, and JSON API.
 
 ## Sponsors
 


### PR DESCRIPTION
## Summary

Adding [What Broke Today](https://whatbroke.today/) to the Open Source Projects section.

**What Broke Today** is an AI-powered outage aggregator built with FastAPI that:
- Monitors 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare, etc.)
- Uses AI to filter and summarize service outages
- Provides real-time Telegram alerts
- Offers RSS feed and JSON API

**Website**: https://whatbroke.today
**Source Code**: https://github.com/reshadat/whatbroketoday
**Tech Stack**: FastAPI, SQLite, Jinja2, Python