### PR TITLE
Add JARVIS - Self-hosted AI assistant platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Compute:
 - [FastAPI Websocket Broadcast](https://github.com/kthwaite/fastapi-websocket-broadcast) - Websocket 'broadcast' demo.
 - [FastAPI with Celery, RabbitMQ, and Redis](https://github.com/GregaVrbancic/fastapi-celery) - Minimal example utilizing FastAPI and Celery with RabbitMQ for task queue, Redis for Celery backend, and Flower for monitoring the Celery tasks.
 - [FuturamaAPI](https://github.com/koldakov/futuramaapi) - A REST and GraphQL playground built with best practices, providing WebSockets, SSE, callbacks, secret messages, and more.
+- [JARVIS](https://github.com/hyhmrright/JARVIS) - Self-hosted AI assistant platform with RAG, multi-LLM support (DeepSeek/OpenAI/Anthropic), plugin SDK, and multi-channel gateway. Built with FastAPI, LangGraph, SQLAlchemy async, and Vue 3.
 - [JeffQL](https://github.com/yezz123/JeffQL/) - Simple authentication and login API using GraphQL and JWT.
 - [JSON-RPC Server](https://github.com/smagafurov/fastapi-jsonrpc) - JSON-RPC server based on FastAPI.
 - [Mailer](https://github.com/rclement/mailer) - Dead-simple mailer micro-service for static websites.


### PR DESCRIPTION
I'm adding JARVIS to the awesome-fastapi Open Source Projects section.

JARVIS is an open-source, self-hosted AI assistant platform that fits this list because:

- **FastAPI backend** with async SQLAlchemy, streaming SSE endpoints, JWT auth, and full OpenAPI docs
- **LangGraph ReAct agent** with multi-LLM orchestration (DeepSeek/OpenAI/Anthropic)
- **Production-ready** features: RAG knowledge base (Qdrant), Plugin SDK, multi-channel gateway (Slack/Discord/Telegram), RBAC, and observability stack (Prometheus/Loki/Grafana)
- **Docker Compose** one-command deployment

Project: https://github.com/hyhmrright/JARVIS
License: MIT

Please let me know if this entry needs any adjustments.