### PR TITLE
Add casbin-fastapi-decorator to Auth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 - [FastAPI Auth](https://github.com/dmontagu/fastapi-auth) - Pluggable auth that supports the OAuth2 Password Flow with JWT access and refresh tokens.
 - [FastAPI Azure Auth](https://github.com/Intility/fastapi-azure-auth) - Azure AD authentication for your APIs with single and multi tenant support.
 - [FastAPI Casbin Auth](https://github.com/officialpycasbin/fastapi-casbin-auth) - Authorization which supports various access control models like RBAC, ReBAC and ABAC through Casbin.
+- [casbin-fastapi-decorator](https://github.com/Neko1313/casbin-fastapi-decorator) - Casbin-powered authorization decorators for FastAPI.
 - [FastAPI Cloud Auth](https://github.com/tokusumi/fastapi-cloudauth) - Simple integration between FastAPI and cloud authentication services (AWS Cognito, Auth0, Firebase Authentication).
 - [FastAPI Login](https://github.com/maxrdu/fastapi_login) - Account management and authentication (based on [Flask-Login](https://github.com/maxcountryman/flask-login)).
 - [FastAPI JWT Auth](https://github.com/IndominusByte/fastapi-jwt-auth) - JWT auth (based on [Flask-JWT-Extended](https://github.com/vimalloc/flask-jwt-extended)).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 - [FastAPI Auth](https://github.com/dmontagu/fastapi-auth) - Pluggable auth that supports the OAuth2 Password Flow with JWT access and refresh tokens.
 - [FastAPI Azure Auth](https://github.com/Intility/fastapi-azure-auth) - Azure AD authentication for your APIs with single and multi tenant support.
 - [FastAPI Casbin Auth](https://github.com/officialpycasbin/fastapi-casbin-auth) - Authorization which supports various access control models like RBAC, ReBAC and ABAC through Casbin.
-- [casbin-fastapi-decorator](https://github.com/Neko1313/casbin-fastapi-decorator) - Casbin-powered authorization decorators for FastAPI.
+- [casbin-fastapi-decorator](https://github.com/Neko1313/casbin-fastapi-decorator) - Decorator-based authorization for FastAPI using Casbin — no middleware, per-route permissions, with optional JWT, async SQLAlchemy, and Casdoor support.
 - [FastAPI Cloud Auth](https://github.com/tokusumi/fastapi-cloudauth) - Simple integration between FastAPI and cloud authentication services (AWS Cognito, Auth0, Firebase Authentication).
 - [FastAPI Login](https://github.com/maxrdu/fastapi_login) - Account management and authentication (based on [Flask-Login](https://github.com/maxcountryman/flask-login)).
 - [FastAPI JWT Auth](https://github.com/IndominusByte/fastapi-jwt-auth) - JWT auth (based on [Flask-JWT-Extended](https://github.com/vimalloc/flask-jwt-extended)).


### PR DESCRIPTION
## What is it?

An authorization decorator factory for FastAPI built on top of [Casbin](https://casbin.org/) and [fastapi-decorators](https://pypi.org/project/fastapi-decorators/).

Unlike the existing Casbin-based entries (`fastapi-authz`, `fastapi-casbin-auth`) which operate as global middleware, this library applies authorization **directly at the route level via decorators** — no middleware setup, no extra parameters in endpoint signatures.

## Key features

- Decorator per route — no global middleware side-effects
- Per-route permission configuration with static or dynamic objects
- Dynamic `AccessSubject` — object resolved from request via FastAPI DI
- Clean endpoint signatures — no injected auth parameters
- Optional extras: JWT (`casbin-fastapi-decorator[jwt]`), async SQLAlchemy DB adapter (`casbin-fastapi-decorator[db]`), Casdoor OAuth2 (`casbin-fastapi-decorator[casdoor]`)
- Fully typed, 100% test coverage, Python 3.10+

## Why it belongs here

The library fills a gap not covered by existing entries: it is the only FastAPI+Casbin integration that is decorator-based rather than middleware-based, and it is already listed in the [official Casbin ecosystem](https://casbin.org/ecosystem/) under the FastAPI section.

## Checklist

- [x] The entry is alphabetically ordered within the section
- [x] The description is concise and consistent with the list style
- [x] The project is open source with an MIT license
- [x] The project is available on [PyPI](https://pypi.org/project/casbin-fastapi-decorator/)
- [x] The project has documentation and examples