### PR TITLE
Add Visura API to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Compute:
 - [Slackers](https://github.com/uhavin/slackers) - Slack webhooks API.
 - [TermPair](https://github.com/cs01/termpair) - View and control terminals from your browser with end-to-end encryption.
 - [Universities](https://github.com/ycd/universities) - API service for obtaining information about +9600 universities worldwide.
+- [Visura API](https://github.com/zornade/visura-api) - REST API for automated Italian cadastral property record extraction (visure catastali) from the SISTER portal, using Playwright for browser automation with SPID authentication.
 
 ## Sponsors
 


### PR DESCRIPTION
## Add Visura API

**Project:** [visura-api](https://github.com/zornade/visura-api)

**Description:** REST API for automated Italian cadastral property record extraction (visure catastali) from the SISTER portal, using Playwright for browser automation with SPID authentication.

### Why it belongs here

- Built with **FastAPI** as the web framework
- Uses **Playwright** for headless browser automation
- Production-ready with Docker support, sequential queue, session keep-alive, and automatic recovery
- Real-world open source project solving the problem of missing APIs for Italian public cadastral data
- AGPL-3.0 licensed

### Tech stack
- FastAPI 0.115+
- Playwright (Python)
- Python 3.11+
- Docker / Docker Compose

Thank you for maintaining this awesome list!
