### PR TITLE
Add FoJin - Buddhist digital text platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Compute:
 - [DogeAPI](https://github.com/yezz123/DogeAPI) - API with high performance to create a simple blog and CRUD with OAuth2PasswordBearer.
 - [FastAPI Websocket Broadcast](https://github.com/kthwaite/fastapi-websocket-broadcast) - Websocket 'broadcast' demo.
 - [FastAPI with Celery, RabbitMQ, and Redis](https://github.com/GregaVrbancic/fastapi-celery) - Minimal example utilizing FastAPI and Celery with RabbitMQ for task queue, Redis for Celery backend, and Flower for monitoring the Celery tasks.
+- [FoJin](https://github.com/xr843/fojin) - Buddhist digital text platform aggregating 440+ sources in 30 languages with full-text search, knowledge graph, and RAG-powered AI Q&A. Built with async SQLAlchemy, pgvector, Elasticsearch 8, and Pydantic v2.
 - [FuturamaAPI](https://github.com/koldakov/futuramaapi) - A REST and GraphQL playground built with best practices, providing WebSockets, SSE, callbacks, secret messages, and more.
 - [JeffQL](https://github.com/yezz123/JeffQL/) - Simple authentication and login API using GraphQL and JWT.
 - [JSON-RPC Server](https://github.com/smagafurov/fastapi-jsonrpc) - JSON-RPC server based on FastAPI.


### PR DESCRIPTION
Adding [FoJin](https://github.com/xr843/fojin) to the Open Source Projects section.

FoJin is a full-featured FastAPI application for Buddhist digital text research, featuring:
- Async SQLAlchemy with PostgreSQL + pgvector
- Elasticsearch 8 with ICU analysis for CJK full-text search
- Pydantic v2 schemas
- RAG-powered AI Q&A via Dify integration
- Docker Compose deployment

Live demo: https://fojin.app