### PR TITLE
Add FastAPI Blueprint to Boilerplate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Compute:
 - [fastapi-starter-project](https://github.com/mirzadelic/fastapi-starter-project) - A project template which uses FastAPI, SQLModel, Alembic, Pytest, Docker, GitHub Actions CI.
 - [Full Stack FastAPI and MongoDB - Base Project Generator](https://github.com/mongodb-labs/full-stack-fastapi-mongodb) - Full stack, modern web application generator, which includes FastAPI, MongoDB, Docker, Celery, React frontend, automatic HTTPS and more.
 - [Uvicorn Poetry FastAPI Project Template](https://github.com/max-pfeiffer/uvicorn-poetry-fastapi-project-template) - Cookiecutter project template for starting a FastAPI application. Runs in a Docker container with Uvicorn ASGI server on Kubernetes. Supports AMD64 and ARM64 CPU architectures.
+- [FastAPI Blueprint](https://github.com/Mr-DooSun/fastapi-blueprint) - Production-ready template with zero-boilerplate CRUD via generic base classes, auto domain discovery, DDD layered architecture, and pre-commit architecture enforcement.
 
 ### Docker Images
 


### PR DESCRIPTION
Adding [FastAPI Blueprint](https://github.com/Mr-DooSun/fastapi-blueprint) to the Boilerplate section.

**What it is:** A production-ready FastAPI backend template built around DDD layered architecture.

**Why it's useful:**
- Zero-boilerplate CRUD — inherit `BaseRepository[DTO]` + `BaseService[DTO]`, get 7 async methods instantly
- Auto domain discovery — add a domain folder, it registers itself. No manual container/bootstrap changes
- Architecture enforcement — pre-commit hooks block Domain → Infrastructure imports at commit time
- Type-safe generics across all layers
- 4 interface types from one domain logic (HTTP API, Async Worker, Admin UI, MCP Server)
- 14 Architecture Decision Records documenting every design choice