### PR TITLE
Add scalekit-sdk-python to Auth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [FastAPI Security](https://github.com/jacobsvante/fastapi-security) - Implements authentication and authorization as dependencies in FastAPI.
 - [FastAPI Simple Security](https://github.com/mrtolkien/fastapi_simple_security) - Out-of-the-box API key security manageable through path operations.
 - [FastAPI Users](https://github.com/fastapi-users/fastapi-users) - Account management, authentication, authorization.
+- [scalekit-sdk-python](https://github.com/scalekit-inc/scalekit-sdk-python) - Official Python client for Scalekit (SAML/OIDC SSO, SCIM, OAuth 2.1, Agent Auth, MCP); use with FastAPI for B2B and AI/agent workloads.
 
 ### CyberSecurity
 


### PR DESCRIPTION
Adds the official [scalekit-sdk-python](https://github.com/scalekit-inc/scalekit-sdk-python) client under **Auth** for teams using FastAPI with Scalekit for enterprise SSO, SCIM, OAuth 2.1, Agent Auth, and MCP.