### PR TITLE
Add SnapDeploy to PaaS hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@
 - [Google App Engine](https://cloud.google.com/appengine)
 - [Heroku](https://www.heroku.com/) ([Step-by-step tutorial](https://tutlinks.com/create-and-deploy-fastapi-app-to-heroku/), [ML model on Heroku tutorial](https://testdriven.io/blog/fastapi-machine-learning/))
 - [Microsoft Azure App Service](https://azure.microsoft.com/en-us/products/app-service/)
+- [SnapDeploy](https://snapdeploy.dev) - Docker-native container hosting with free tier. Auto-detects FastAPI and configures uvicorn. GitHub auto-deploy on push.
 
 ### IaaS
 


### PR DESCRIPTION
Adding SnapDeploy as a PaaS option for FastAPI deployment.

SnapDeploy auto-detects FastAPI apps from requirements.txt, configures
uvicorn with the correct port (8000), and deploys as a Docker container.

- Free tier: up to 4 containers, no credit card
- GitHub auto-deploy on push
- Auto-detects FastAPI and sets up uvicorn with --workers
- Managed database add-ons available

GitHub Marketplace: https://github.com/marketplace/snapdeploy-app