### PR TITLE
Add FreeFile ITR to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Compute:
 - [Bunnybook](https://github.com/pietrobassi/bunnybook) - A tiny social network built with FastAPI, React+RxJs, Neo4j, PostgreSQL, and Redis.
 - [Coronavirus-tg-api](https://github.com/egbakou/coronavirus-tg-api) - API for tracking the global coronavirus (COVID-19, SARS-CoV-2) outbreak.
 - [Dispatch](https://github.com/Netflix/dispatch) - Manage security incidents.
+- [FreeFile ITR](https://github.com/rohitthink/freefile) - Free, privacy-first income tax return filing app for Indian freelancers. FastAPI backend with bank statement parsers, tax computation engine, and Playwright-based filing automation. Packaged with Next.js frontend and Tauri desktop shell.
 - FastAPI CRUD Example:
   - [Async flavor](https://github.com/testdrivenio/fastapi-crud-async)
   - [Sync Flavor](https://github.com/testdrivenio/fastapi-crud-sync)


### PR DESCRIPTION
Adding **FreeFile ITR** — an open source income tax return filing application built with FastAPI.

**Project:** https://github.com/rohitthink/freefile
**License:** AGPL-3.0

## What it uses from FastAPI

- FastAPI for the REST API (10+ routes)
- Pydantic for data models and validation
- \`aiosqlite\` for async SQLite database access
- \`sse-starlette\` for server-sent events (live filing progress)
- Uvicorn as the ASGI server
- PyInstaller to bundle the FastAPI app as a sidecar binary for Tauri desktop

## What it does

FreeFile is a privacy-first income tax return filing app for Indian freelancers. It parses bank statements from Indian banks (HDFC, SBI, ICICI, Axis, Kotak), auto-categorizes transactions, computes tax under both old and new regimes (FY 2025-26), and uses Playwright to automate filing on the official tax portal. All data stays on the user's device.

The FastAPI backend exposes a rich API (upload, transactions, tax, filing, profile, capital gains) consumed by a Next.js frontend. It demonstrates a non-trivial, production-ready FastAPI application with async database access, PDF parsing, streaming responses, and browser automation integration.

Thanks!