### PR TITLE
Add Simplehook

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 - [OpenTelemetry FastAPI Instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi) - Library provides automatic and manual instrumentation of FastAPI web frameworks, instrumenting http requests served by applications utilizing the framework.
 - [Prerender Python Starlette](https://github.com/BeeMyDesk/prerender-python-starlette) - Starlette middleware for Prerender.
 - [Prometheus FastAPI Instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator) - A configurable and modular Prometheus Instrumentator for your FastAPI application.
+- [Simplehook](https://simplehook.dev/) - Receive webhooks at a stable URL in your FastAPI app with one line of code. Also exposes a Pull API for AI agents.
 - [SlowApi](https://github.com/laurents/slowapi) - Rate limiter (based on [Flask-Limiter](https://flask-limiter.readthedocs.io)).
 - [Starlette Context](https://github.com/tomwojcik/starlette-context) - Allows you to store and access the request data anywhere in your project, useful for logging.
 - [Starlette Exporter](https://github.com/stephenhillier/starlette_exporter) - One more prometheus integration for FastAPI and Starlette.


### PR DESCRIPTION
Adds [Simplehook](https://simplehook.dev/) to the **Third-Party Extensions > Utils** section.

## What it is

Simplehook is a webhook delivery service that gives developers a permanent, stable webhook URL. For FastAPI specifically, it ships a small pip package (`simplehook-fastapi`) so that adding webhook support to a FastAPI app is a single line of code:

```python
from simplehook_fastapi import listen_to_webhooks

listen_to_webhooks(app)
```

The FastAPI app then receives webhooks locally via an outbound WebSocket, so the URL stays the same across restarts, machines, and teammates — no tunnels to manage. There is also a Pull API that lets AI agents (Mastra, Claude, etc.) pull webhook events as JSON.

## Why it fits

The Utils section already includes similar developer-facing integrations (CloudEvents, websocket pub/sub, events dispatching, MQTT, socketio). A first-class FastAPI webhook-receiver extension is a natural addition.

## Placement

Inserted alphabetically in Utils (between `Prometheus FastAPI Instrumentator` and `SlowApi`).

Free tier available. Source: https://github.com/bnbarak/antiwebhook