### PR TITLE
Add fastapi-error-handler to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [FastAPI Opentracing](https://github.com/wesdu/fastapi-opentracing) - Opentracing middleware and database tracing support for FastAPI.
 - [FastAPI Pagination](https://github.com/uriyyo/fastapi-pagination) - Pagination for FastAPI.
 - [FastAPI Plugins](https://github.com/madkote/fastapi-plugins) - Redis and Scheduler plugins.
+- [FastAPI Error Handler](https://github.com/shahabRDZ/fastapi-error-handler) - Elegant, consistent error handling with structured JSON responses — one line setup.
 - [FastAPI ServiceUtils](https://github.com/skallfass/fastapi_serviceutils) - Generator for creating API services.
 - [FastAPI Shield](https://github.com/jymchng/fastapi-shield) - General FastAPI library for writing any generic endpoint decorators capable of lazy dependencies injection.
 - [FastAPI SocketIO](https://github.com/pyropy/fastapi-socketio) - Easy integration for FastAPI and SocketIO.


### PR DESCRIPTION
Adding [fastapi-error-handler](https://github.com/shahabRDZ/fastapi-error-handler) to the Utils section.

**What it does:** Provides consistent, structured JSON error responses for FastAPI with one line of setup. Handles AppError subclasses, Pydantic validation errors, Starlette HTTP exceptions, and unhandled exceptions.

- 8 built-in exception classes (NotFoundError, BadRequestError, etc.)
- Consistent response format: `{"error": "not_found", "message": "...", "status": 404}`
- Request ID tracking
- Configurable error callbacks (Sentry, etc.)
- 17 tests
- MIT licensed