### PR TITLE
Add LocoPilot to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Compute:
 - [FuturamaAPI](https://github.com/koldakov/futuramaapi) - A REST and GraphQL playground built with best practices, providing WebSockets, SSE, callbacks, secret messages, and more.
 - [JeffQL](https://github.com/yezz123/JeffQL/) - Simple authentication and login API using GraphQL and JWT.
 - [JSON-RPC Server](https://github.com/smagafurov/fastapi-jsonrpc) - JSON-RPC server based on FastAPI.
+- [LocoPilot](https://github.com/bobfromarcher/LocoPilot) - Vision, browser, and desktop control for any local LLM. FastAPI server with 35 REST endpoints, runs on localhost via Ollama.
 - [Mailer](https://github.com/rclement/mailer) - Dead-simple mailer micro-service for static websites.
 - [Markdown-Videos](https://github.com/Snailedlt/Markdown-Videos) - API for generating thumbnails to embed into your markdown content.
 - [Nemo](https://github.com/harshitsinghai77/nemo-backend) - Be productive with Nemo.


### PR DESCRIPTION
## Summary

Adds [LocoPilot](https://github.com/bobfromarcher/LocoPilot) to the Open Source Projects section.

LocoPilot is a FastAPI REST API server that provides vision, browser, and desktop control for any local LLM. It exposes 35 endpoints, runs on localhost via Ollama with zero cloud dependencies, and is MIT-licensed.

Placed alphabetically between JSON-RPC Server and Mailer, matching the existing list format.