### PR TITLE
Add tracemaid to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - [Manage FastAPI](https://github.com/ycd/manage-fastapi) - CLI tool for generating and managing FastAPI projects.
 - [msgpack-asgi](https://github.com/florimondmanca/msgpack-asgi) - Automatic [MessagePack](https://msgpack.org/) content negotiation.
 - [python-cqrs](https://github.com/pypatterns/python-cqrs) - Event-Driven Architecture Framework with CQRS, Transaction Outbox, Saga orchestration, seamless FastAPI/FastStream integration.
+- [tracemaid](https://github.com/karthyick/tracemaid) - Auto-generate Mermaid call graphs from OpenTelemetry traces. Visualizes FastAPI request paths, async chains, and LLM agent flows from existing OTel spans.
 
 ### Email
 


### PR DESCRIPTION
Adding [**tracemaid**](https://github.com/karthyick/tracemaid) under **Third-Party Extensions → Developer Tools**.

Tracemaid auto-generates **Mermaid call graphs from OpenTelemetry traces** for Python services. For FastAPI users it's especially useful to:
- Visualize the full request path across async middleware, dependencies, and route handlers
- See parent-child span timing without leaving the codebase
- Generate diagrams from existing OTel instrumentation — no new code

- `pip install tracemaid`
- MIT license
- Works with any Python app emitting OTel spans (FastAPI / Starlette / Flask)

Thanks for maintaining this list!