### PR TITLE
Add DeepAlpha to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Compute:
 - [Bunnybook](https://github.com/pietrobassi/bunnybook) - A tiny social network built with FastAPI, React+RxJs, Neo4j, PostgreSQL, and Redis.
 - [Coronavirus-tg-api](https://github.com/egbakou/coronavirus-tg-api) - API for tracking the global coronavirus (COVID-19, SARS-CoV-2) outbreak.
 - [Dispatch](https://github.com/Netflix/dispatch) - Manage security incidents.
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI-powered crypto trading bot with ML ensemble, 12 exchanges, real-time dashboard, and REST API built with FastAPI.
 - FastAPI CRUD Example:
   - [Async flavor](https://github.com/testdrivenio/fastapi-crud-async)
   - [Sync Flavor](https://github.com/testdrivenio/fastapi-crud-sync)


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the Open Source Projects section.

**DeepAlpha** is an open-source AI crypto trading bot built with **FastAPI** for its REST API and real-time dashboard. Features:
- FastAPI-powered REST API and WebSocket endpoints
- 3-model ML ensemble (XGBoost, LightGBM, CatBoost)
- 12 exchanges via CCXT
- Real-time trading dashboard

Thank you for maintaining this awesome list!