### PR TITLE
Add Anime Tracker to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Compute:
 - [uvicorn-poetry](https://github.com/max-pfeiffer/uvicorn-poetry) - Docker image with Uvicorn ASGI server for running Python web applications on Kubernetes. Uses Poetry for managing dependencies and setting up a virtual environment. Supports AMD64 and ARM64 CPU architectures.
 
 ### Open Source Projects
-
+- [Anime Tracker](https://github.com/lucasusamentiaga/anime-tracker) - Self-hosted desktop app to manage your anime list with statistics, notifications, mobile WiFi access via PWA, weekly calendar, 4 languages and 8 search sources (AniList, MAL, Kitsu, Crunchyroll...). Python + FastAPI + SQLite.
 - [Astrobase](https://github.com/anthonycorletti/astrobase) - Simple, fast, and secure deployments anywhere.
 - [Awesome FastAPI Projects](https://github.com/Kludex/awesome-fastapi-projects) - Organized list of projects that use FastAPI.
 - [Bitcart](https://github.com/bitcart/bitcart) - Platform for merchants, users and developers which offers easy setup and use.


### PR DESCRIPTION
## Adding: Anime Tracker

Self-hosted desktop app for managing anime lists, built with Python 3.9+ / FastAPI / SQLite.

### Why it fits the list

- ✅ Built with **FastAPI** (70+ async routes, `run_in_executor` pattern for blocking API calls)
- ✅ **Open source** (MIT licensed)
- ✅ **Active**: just released v1.0.0
- ✅ Demonstrates **practical FastAPI use** beyond simple CRUD

### Features

- 8 pluggable scrapers (AniList GraphQL, Jikan v4 REST, Kitsu JSON:API, Crunchyroll v2, plus 4 HTML scrapers)
- Web Notifications, PWA mobile access via local WiFi
- Statistics dashboard with charts
- Multi-language (ES/EN/FR/DE)
- PyInstaller distribution for Windows

### Repository

https://github.com/lucasusamentiaga/anime-tracker

### Checklist

- [x] Project is open source with a clear license
- [x] Uses FastAPI as the backend framework
- [x] Has a working README
- [x] Added in alphabetical order in the Open Source Projects section
- [x] Description follows the existing format