### PR TITLE
docs: add Schemato to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@
 
 #### Other Tools
 
+- [Schemato](https://www.schemato.top/json-schema-to-pydantic) - Browser-only tool for generating Pydantic v2 models from JSON Schema, OpenAPI, SQL DDL, GraphQL SDL, Prisma, Mongoose, Protobuf, Avro, TypeScript, and JSON.
 - [Pydantic-SQLAlchemy](https://github.com/tiangolo/pydantic-sqlalchemy) - Convert SQLAlchemy models to [Pydantic](https://docs.pydantic.dev/latest/) models.
 - [FastAPI-CamelCase](https://nf1s.github.io/fastapi-camelcase/) - CamelCase JSON support for FastAPI utilizing [Pydantic](https://docs.pydantic.dev/latest/).
   - [CamelCase Models with FastAPI and Pydantic](https://medium.com/analytics-vidhya/camel-case-models-with-fast-api-and-pydantic-5a8acb6c0eee) - Accompanying blog post from the author of the extension.
+  
  
 ### Dependency Injection
 - [Wireup](https://github.com/maldoinc/wireup) - Inject dependencies with zero runtime overhead in FastAPI; Share dependencies across web, cli or other interfaces.


### PR DESCRIPTION
## Project Information

1. **Project Name:**

Schemato

2. **Project URL:**

https://github.com/weitaishan/schemato

3. **Description:**

Schemato is a browser-only schema converter that can generate Pydantic v2 models from JSON Schema, OpenAPI specs, SQL DDL, GraphQL SDL, Prisma, Mongoose, Protobuf, Avro, TypeScript, and JSON samples.

For FastAPI projects, it can help turn API specs, database schemas, or sample payloads into request/response model drafts.

----

## Criteria

1. **Is the project new?**
   - [x] Yes
   - [ ] No

2. **How long has the project been maintained?**

The project is new and has been maintained for less than one year.

3. **How many releases has it had if it's a library or package?**

It is currently a web tool/static site rather than a published library package. There are no package releases yet.

4. **Are you the author, or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**

FastAPI users often work from OpenAPI specs, JSON Schema files, database schemas, or real API payloads and then need Pydantic models. Schemato provides a quick browser-only way to generate Pydantic v2 model drafts without uploading schemas to a backend service.

It is especially useful for prototyping request/response models or exploring how external schema formats map into Pydantic.

----

## AI Disclosure

- [x] Yes, this pull request was generated or assisted by AI.
- [ ] No, this pull request was authored entirely by a human.

----

## Additional Information

Disclosure: I am the maintainer of Schemato.

The project is new and may not yet meet the list's maturity threshold. I am submitting it because the Pydantic/OpenAPI workflow is directly relevant to FastAPI users, but I understand if the maintainers prefer to wait until the project has more usage history or community traction.