### PR TITLE
Add seo-sidecar to Utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 - [Starlette Prometheus](https://github.com/perdy/starlette-prometheus) - Prometheus integration for FastAPI and Starlette.
 - [Strawberry GraphQL](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses.
 - [Pydantic Resolve](https://github.com/allmonday/pydantic-resolve) -  Turns pydantic class into a powerful composable computing container by introducing resolve and post-process hooks.
+- [seo-sidecar](https://github.com/Janady13/seo-sidecar) - FastAPI service that receives Schema.org JSON-LD pushes from upstream and serves them to nginx via SSI. Zero crons, zero site file changes, always fresh. Comes with Python + Go push clients and a systemd unit.
 
 ## Resources
 


### PR DESCRIPTION
Adds [seo-sidecar](https://github.com/Janady13/seo-sidecar) to the **Utils** subsection.

It's a FastAPI service that receives Schema.org JSON-LD pushes from upstream and serves them to nginx via SSI. Lets sites get instant schema updates without redeploying. Used in production for 9 client websites at [ThatDevPro](https://www.thatdevpro.com).

- MIT licensed
- Python + Go push clients
- nginx SSI drop-in config
- systemd unit
- SQLite version history