### PR TITLE
Add Inalpha to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Compute:
 - [FastAPI Websocket Broadcast](https://github.com/kthwaite/fastapi-websocket-broadcast) - Websocket 'broadcast' demo.
 - [FastAPI with Celery, RabbitMQ, and Redis](https://github.com/GregaVrbancic/fastapi-celery) - Minimal example utilizing FastAPI and Celery with RabbitMQ for task queue, Redis for Celery backend, and Flower for monitoring the Celery tasks.
 - [FuturamaAPI](https://github.com/koldakov/futuramaapi) - A REST and GraphQL playground built with best practices, providing WebSockets, SSE, callbacks, secret messages, and more.
+- [Inalpha](https://github.com/mirror29/inalpha) - Multi-agent quant research framework whose data, backtest/paper-trading, research, and factor services are FastAPI microservices orchestrated by TypeScript agents.
 - [JeffQL](https://github.com/yezz123/JeffQL/) - Simple authentication and login API using GraphQL and JWT.
 - [JSON-RPC Server](https://github.com/smagafurov/fastapi-jsonrpc) - JSON-RPC server based on FastAPI.
 - [Mailer](https://github.com/rclement/mailer) - Dead-simple mailer micro-service for static websites.


### PR DESCRIPTION
Adds [Inalpha](https://github.com/mirror29/inalpha) to Open Source Projects in alphabetical order (between FuturamaAPI and JeffQL). Inalpha is an open-source (AGPL-3.0) multi-agent quant research framework — its data, backtest/paper-trading, research, and factor services are FastAPI microservices orchestrated by TypeScript agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)