### PR TITLE
Add modern-di to Dependency Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
  
 ### Dependency Injection
 - [Wireup](https://github.com/maldoinc/wireup) - Inject dependencies with zero runtime overhead in FastAPI; Share dependencies across web, cli or other interfaces.
+- [modern-di](https://github.com/modern-python/modern-di) - Dependency injection framework with IoC container and scopes, with a [FastAPI integration](https://github.com/modern-python/modern-di-fastapi).
 
 ### Developer Tools
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@
   - [CamelCase Models with FastAPI and Pydantic](https://medium.com/analytics-vidhya/camel-case-models-with-fast-api-and-pydantic-5a8acb6c0eee) - Accompanying blog post from the author of the extension.
  
 ### Dependency Injection
-- [Wireup](https://github.com/maldoinc/wireup) - Inject dependencies with zero runtime overhead in FastAPI; Share dependencies across web, cli or other interfaces.
+
 - [modern-di](https://github.com/modern-python/modern-di) - Dependency injection framework with IoC container and scopes, with a [FastAPI integration](https://github.com/modern-python/modern-di-fastapi).
+- [Wireup](https://github.com/maldoinc/wireup) - Inject dependencies with zero runtime overhead in FastAPI; Share dependencies across web, cli or other interfaces.
 
 ### Developer Tools
 


### PR DESCRIPTION
Adds [modern-di](https://github.com/modern-python/modern-di) (≈56★, MIT) to the Dependency Injection section: a DI framework with IoC container and scopes, with a dedicated [FastAPI integration](https://github.com/modern-python/modern-di-fastapi). Single item with a description.