### PR TITLE
Add saas-genai-starter to Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Compute:
 - [fastapi-starter-project](https://github.com/mirzadelic/fastapi-starter-project) - A project template which uses FastAPI, SQLModel, Alembic, Pytest, Docker, GitHub Actions CI.
 - [Full Stack FastAPI and MongoDB - Base Project Generator](https://github.com/mongodb-labs/full-stack-fastapi-mongodb) - Full stack, modern web application generator, which includes FastAPI, MongoDB, Docker, Celery, React frontend, automatic HTTPS and more.
 - [Uvicorn Poetry FastAPI Project Template](https://github.com/max-pfeiffer/uvicorn-poetry-fastapi-project-template) - Cookiecutter project template for starting a FastAPI application. Runs in a Docker container with Uvicorn ASGI server on Kubernetes. Supports AMD64 and ARM64 CPU architectures.
+- [saas-genai-starter](https://github.com/delmalih/saas-genai-starter) - Production-grade multi-tenant GenAI SaaS starter built on FastAPI: a bring-your-own-key LLM layer (8 providers), RAG with citations on pgvector, per-tenant usage and cost tracking, an LLM-judge eval harness, and a $0/month Cloud Run + Neon deployment.
 
 ### Docker Images
 


### PR DESCRIPTION
Adds [saas-genai-starter](https://github.com/delmalih/saas-genai-starter) to **Projects → Boilerplate**.

Why it's awesome (and FastAPI-relevant):

- A **production-grade** FastAPI backend, not a demo: async SQLAlchemy 2 with strict ruff + mypy, multi-tenancy enforced in the repository layer (with dedicated cross-tenant isolation tests), Alembic, OpenTelemetry, and a typed client generated from the OpenAPI schema.
- A **bring-your-own-key LLM layer** spanning 8 providers behind one interface (Anthropic, OpenAI, Gemini, Mistral, xAI, DeepSeek, Groq, OpenRouter), with retries/circuit-breaker resilience, RAG with citations on pgvector, per-tenant usage & cost accounting, and an LLM-judge eval harness.
- Background jobs with **no always-on worker** in prod: FastAPI enqueues Cloud Tasks, which push OIDC-signed requests back to the same scale-to-zero service — a **$0/month** deploy (Cloud Run + Neon + Upstash).
- Open-source (MIT), [live demo](https://saas-genai-starter-web.vercel.app), CI green.

One PR, one addition at the end of the Boilerplate section, per the contributing guide.