### PR TITLE
Add yara-orm to ORMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
   - [Aerich](https://github.com/tortoise/aerich) - Tortoise ORM migrations tools.
 - [Saffier ORM](https://github.com/tarsil/saffier) - The only Python ORM you will ever need.
 - [SQLModel](https://sqlmodel.tiangolo.com/) - SQLModel (which is powered by Pydantic and SQLAlchemy) is a library for interacting with SQL databases from Python code, with Python objects.
+- [yara-orm](https://github.com/vsdudakov/yara-orm) - Fast async ORM with a Rust engine; Tortoise-style models, querysets, relations and migrations for PostgreSQL and SQLite.
 
 #### Query Builders
 


### PR DESCRIPTION
Adds [yara-orm](https://github.com/vsdudakov/yara-orm) to the ORMs section.

A Tortoise-style async ORM (models, querysets, relations, migrations) whose engine — connection pooling, parameter binding and row decoding — is written in Rust (tokio-postgres + rusqlite via PyO3). Supports PostgreSQL and SQLite, fully typed, on PyPI.

Disclosure: I'm the author. Entry placed alphabetically and follows the list's `- [name](url) - Description.` format.