### PR TITLE
Add FastAdmin to Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 
 ### Admin
 
+- [FastAdmin](https://github.com/vsdudakov/fastadmin) - Easy-to-use admin dashboard for FastAPI (also Flask and Django), inspired by Django Admin.
 - [FastAPI Admin](https://github.com/fastapi-admin/fastapi-admin) - Functional admin panel that provides a user interface for performing CRUD operations on your data. Currently only works with the Tortoise ORM.
 - [FastAPI Amis Admin](https://github.com/amisadmin/fastapi-amis-admin) - A high-performance, efficient and easily extensible FastAPI admin framework.
 - [Piccolo Admin](https://github.com/piccolo-orm/piccolo_admin) - A powerful and modern admin GUI, using the Piccolo ORM.


### PR DESCRIPTION
Adds [FastAdmin](https://github.com/vsdudakov/fastadmin) to the Admin section.

An easy-to-use admin dashboard for FastAPI (and Flask/Django), inspired by Django Admin — model registration, CRUD UI, filters and actions. Documented and published on PyPI.

Disclosure: I'm the author. Entry placed alphabetically and follows the list's `- [name](url) - Description.` format.