### PR TITLE
Add weckr-fastapi-starter to Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Compute:
 - [fastapi-starter-project](https://github.com/mirzadelic/fastapi-starter-project) - A project template which uses FastAPI, SQLModel, Alembic, Pytest, Docker, GitHub Actions CI.
 - [Full Stack FastAPI and MongoDB - Base Project Generator](https://github.com/mongodb-labs/full-stack-fastapi-mongodb) - Full stack, modern web application generator, which includes FastAPI, MongoDB, Docker, Celery, React frontend, automatic HTTPS and more.
 - [Uvicorn Poetry FastAPI Project Template](https://github.com/max-pfeiffer/uvicorn-poetry-fastapi-project-template) - Cookiecutter project template for starting a FastAPI application. Runs in a Docker container with Uvicorn ASGI server on Kubernetes. Supports AMD64 and ARM64 CPU architectures.
+- [weckr-fastapi-starter](https://github.com/Ghiles3232/weckr-fastapi-starter) - FastAPI AI SaaS starter with per user AI cost and margin tracking built in from the first request.
 
 ### Docker Images
 


### PR DESCRIPTION
Adding weckr-fastapi-starter, a FastAPI AI SaaS boilerplate with per user AI cost and margin tracking wired in from the first request. Useful for anyone shipping an LLM feature who wants unit economics visibility from day one.