### PR TITLE
Add Production AI Document Backend to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Compute:
 - [OPAL (Open Policy Administration Layer)](https://github.com/authorizon/opal) - Real-time authorization updates on top of Open-Policy; built with FastAPI, Typer, and FastAPI WebSocket pub/sub.
 - [OSBot-Fast-API](https://github.com/owasp-sbot/OSBot-Fast-API) - Type-safe FastAPI wrapper that provides middleware, HTTP event tracking, AWS Lambda integration, test utilities, and auto-conversion between Type_Safe, Pydantic, and dataclasses.
 - [Polar](https://github.com/polarsource/polar) - A funding and monetization platform for developers, built with FastAPI, SQLAlchemy, Alembic, and Arq.
+- [Production AI Document Backend](https://github.com/vinsblack/production-ai-document-backend) - Asynchronous invoice extraction built so a job cannot be silently lost: FastAPI, ARQ, PostgreSQL as the source of truth, a recoverable Redis handoff, terminal-vs-retryable failure classification, and CI that round-trips Alembic migrations against real PostgreSQL and Redis.
 - [RealWorld Example App - mongo](https://github.com/markqiu/fastapi-mongodb-realworld-example-app)
 - [RealWorld Example App - postgres](https://github.com/nsidnev/fastapi-realworld-example-app)
 - [redis-streams-fastapi-chat](https://github.com/leonh/redis-streams-fastapi-chat) - A simple Redis Streams backed chat app using Websockets, Asyncio and FastAPI/Starlette.


### PR DESCRIPTION
Adds one entry to Open Source Projects, in alphabetical position between Polar and RealWorld Example App.

An asynchronous document extraction service (FastAPI + ARQ + PostgreSQL + Redis) whose focus is job durability: the document and its `QUEUED` job are committed to PostgreSQL before the Redis enqueue, so a failed handoff leaves the job recoverable rather than lost. Retryability is a classification rather than a counter — a document that can never succeed is not retried — and CI round-trips Alembic migrations (`upgrade → downgrade -1 → upgrade`) against real PostgreSQL and Redis.

MIT licensed, CI green, 90% coverage gate enforced, and a reproducible end-to-end demo in `docs/demo.md` that needs no API key.