### PR TITLE
Add FastAPI Agent Blueprint to Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Compute:
 - [fastapi-starter-project](https://github.com/mirzadelic/fastapi-starter-project) - A project template which uses FastAPI, SQLModel, Alembic, Pytest, Docker, GitHub Actions CI.
 - [Full Stack FastAPI and MongoDB - Base Project Generator](https://github.com/mongodb-labs/full-stack-fastapi-mongodb) - Full stack, modern web application generator, which includes FastAPI, MongoDB, Docker, Celery, React frontend, automatic HTTPS and more.
 - [Uvicorn Poetry FastAPI Project Template](https://github.com/max-pfeiffer/uvicorn-poetry-fastapi-project-template) - Cookiecutter project template for starting a FastAPI application. Runs in a Docker container with Uvicorn ASGI server on Kubernetes. Supports AMD64 and ARM64 CPU architectures.
+- [FastAPI Agent Blueprint](https://github.com/Mr-DooSun/fastapi-agent-blueprint) - DDD layered template where generic base classes give async CRUD with no boilerplate, domains self-register on discovery, and pre-commit hooks block cross-layer imports at commit time.
 
 ### Docker Images
 


### PR DESCRIPTION
You asked me to open this again in August 2026 — so, here in August.

This is a fresh PR rather than a reopen of #253: GitHub refuses to reopen that
one (422, no reason given), and the repo was renamed since March, so the link
would have been wrong anyway.

On the "at least a year old, consistently updated" bar — that was the sticking
point last time, and it is now something you can check rather than something I
assert. The GitHub repo dates from March 2026, but the git history inside it
starts 2024-11-05: 1115 commits, present in 19 of the last 22 months, ~120/month
since May. `git clone && git log --reverse | head` shows it in one command.
v0.10.0 shipped yesterday and v0.10.1 today.

Why I think it earns a slot: it is the only entry in Boilerplate that pairs a
DDD layered structure with enforcement rather than convention — generic base
classes give async CRUD with no per-domain boilerplate, new domains
self-register through discovery instead of container edits, and a pre-commit
hook rejects a cross-layer import at commit time. 2016 tests across
PostgreSQL / MySQL / SQLite, 59 ADRs, and 9 runnable examples under `examples/`.

Added at the end of the section per CONTRIBUTING, since Boilerplate is not
alphabetical.

Original thread: #253
