### PR TITLE
[NEW] interlock-cb

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@
 - [Starlette Prometheus](https://github.com/perdy/starlette-prometheus) - Prometheus integration for FastAPI and Starlette.
 - [Strawberry GraphQL](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses.
 - [Pydantic Resolve](https://github.com/KLR-Pattern/pydantic-resolve) -  Turns pydantic class into a powerful composable computing container by introducing resolve and post-process hooks.
+- [interlock](https://github.com/bagowix/interlock) - Circuit breaker for outbound calls with automatic 503 + Retry-After; trips on failure rate and latency, sync and async in one class.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@
 - [Starlette Prometheus](https://github.com/perdy/starlette-prometheus) - Prometheus integration for FastAPI and Starlette.
 - [Strawberry GraphQL](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses.
 - [Pydantic Resolve](https://github.com/KLR-Pattern/pydantic-resolve) -  Turns pydantic class into a powerful composable computing container by introducing resolve and post-process hooks.
-- [interlock](https://github.com/bagowix/interlock) - Circuit breaker for outbound calls with automatic 503 + Retry-After; trips on failure rate and latency, sync and async in one class.
+- [interlock-cb](https://github.com/bagowix/interlock) - Circuit breaker for outbound calls with automatic 503 + Retry-After; trips on failure rate and latency, sync and async in one class.
 
 ## Resources
 


### PR DESCRIPTION
## Project Information

1. **Project Name:**

   interlock

2. **Project URL:**

   https://github.com/bagowix/interlock

3. **Description:**

   A typed circuit breaker for Python that protects FastAPI outbound calls and maps open circuits to HTTP 503 responses with Retry-After.

----

## Criteria

1. **Is the project new?**
   - [x] Yes
   - [ ] No

2. **How long has the project been maintained?**

   Approximately six weeks, since June 2026. The project is actively maintained, but it has not yet reached the preferred one-year history.

3. **How many releases has it had if it is a library or package?**

   12 releases: https://github.com/bagowix/interlock/releases

4. **Are you the author, or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**

   interlock gives FastAPI applications a focused resilience integration: dependency-injected circuit breakers and an exception handler that converts an open circuit into a standards-friendly 503 response with Retry-After. The breaker supports sync and async code through one typed API, trips on failure rate over a sliding window and on slow calls, and keeps its core dependency-free.

----

## AI Disclosure

- [x] Yes, this pull request was generated or assisted by AI.
- [ ] No, this pull request was authored entirely by a human.

----

## Additional Information

I am the author of interlock. The FastAPI integration is documented at https://bagowix.github.io/interlock/integrations/fastapi/ and is available through the optional interlock-cb[fastapi] extra. The project currently has fewer than 100 stars and is younger than one year; I am submitting it transparently because it directly solves outbound dependency-failure handling for FastAPI services.