### PR TITLE
Add BetterCRUD to Utils list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@
 - [FastAPI Chameleon](https://github.com/mikeckennedy/fastapi-chameleon) - Adds integration of the Chameleon template language to FastAPI.
 - [FastAPI CloudEvents](https://github.com/sasha-tkachev/fastapi-cloudevents) - [CloudEvents](https://cloudevents.io/) integration for FastAPI.
 - [FastAPI Contrib](https://github.com/identixone/fastapi_contrib) - Opinionated set of utilities: pagination, auth middleware, permissions, custom exception handlers, MongoDB support, and Opentracing middleware.
+- [BetterCRUD](https://github.com/bigrivi/better_crud) - Generate complete CRUD routes from a single decorator: rich filtering (27 operators), pagination modes, relationship queries & storage, soft delete + recover, ACL hooks, lifecycle hooks, and custom endpoints via `@crud_action`.
 - [FastAPI FastCRUD](https://github.com/benavlabs/fastcrud)) - Robust async CRUD operations and flexible endpoint creation utilities.
 - [FastAPI Events](https://github.com/melvinkcx/fastapi-events) - Asynchronous event dispatching/handling library for FastAPI and Starlette.
 - [FastAPI FeatureFlags](https://github.com/Pytlicek/fastapi-featureflags) - Simple implementation of feature flags for FastAPI.


### PR DESCRIPTION
## What
Adds [BetterCRUD](https://github.com/bigrivi/better_crud) to the **Utils** section of the Third-Party Extensions list.

## Why
BetterCRUD is an actively-maintained FastAPI CRUD router library that generates complete CRUD routes from a single decorator. It's a strict superset of the now-unmaintained `fastapi-crudrouter` and belongs alongside existing CRUD utilities like FastCRUD.

Key features:
- 8 CRUD routes from one `@crud` decorator (class & function views)
- 27 filter operators + nested `$and`/`$or`
- Pagination modes: `always` / `optional` / `disabled`
- Relationship queries & storage (joins, many-to-many, etc.)
- Soft delete + recover route
- ACL hooks (`get_feature` / `get_action`)
- Lifecycle hooks
- Custom endpoints via `@crud_action`
- 99%+ test coverage, 177 passing tests

## Checklist
- [x] Follows the existing list format (`- [Name](url) - description`)
- [x] Placed alphabetically in the Utils section (after ASGI Correlation ID, before FastAPI Cache)
- [x] No unrelated changes