### PR TITLE
Add Web Metadata & Contact Extractor to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Compute:
 - [Slackers](https://github.com/uhavin/slackers) - Slack webhooks API.
 - [TermPair](https://github.com/cs01/termpair) - View and control terminals from your browser with end-to-end encryption.
 - [Universities](https://github.com/ycd/universities) - API service for obtaining information about +9600 universities worldwide.
+- [Web Metadata & Contact Extractor](https://github.com/JosejuX/rapidapi-metadata-extractor) - Extract SEO/OpenGraph metadata, contacts, tech stack, and clean Markdown from any URL in one call.
 
 ## Sponsors
 


### PR DESCRIPTION
Adds a small open-source FastAPI REST API that extracts SEO/OpenGraph metadata, contact info (emails + social links), detected tech stack, and clean Markdown from any URL in a single call. MIT licensed, live demo included, no auth required to try it.

- Repo: https://github.com/JosejuX/rapidapi-metadata-extractor
- Live demo: https://rapidapi-metadata-extractor.onrender.com