### PR TITLE
Add GeoLens to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Compute:
 - [FastAPI Websocket Broadcast](https://github.com/kthwaite/fastapi-websocket-broadcast) - Websocket 'broadcast' demo.
 - [FastAPI with Celery, RabbitMQ, and Redis](https://github.com/GregaVrbancic/fastapi-celery) - Minimal example utilizing FastAPI and Celery with RabbitMQ for task queue, Redis for Celery backend, and Flower for monitoring the Celery tasks.
 - [FuturamaAPI](https://github.com/koldakov/futuramaapi) - A REST and GraphQL playground built with best practices, providing WebSockets, SSE, callbacks, secret messages, and more.
+- [GeoLens](https://github.com/geolens-io/geolens) - Self-hosted geospatial catalog and map builder on FastAPI and PostGIS.
 - [JeffQL](https://github.com/yezz123/JeffQL/) - Simple authentication and login API using GraphQL and JWT.
 - [JSON-RPC Server](https://github.com/smagafurov/fastapi-jsonrpc) - JSON-RPC server based on FastAPI.
 - [Mailer](https://github.com/rclement/mailer) - Dead-simple mailer micro-service for static websites.


### PR DESCRIPTION
Adds GeoLens under Open Source Projects. The backend is FastAPI on PostGIS. Apache-2.0.

Disclosure: I'm the author.