### PR TITLE
Add OrcaRouter Lite to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Compute:
 - [Markdown-Videos](https://github.com/Snailedlt/Markdown-Videos) - API for generating thumbnails to embed into your markdown content.
 - [Nemo](https://github.com/harshitsinghai77/nemo-backend) - Be productive with Nemo.
 - [OPAL (Open Policy Administration Layer)](https://github.com/authorizon/opal) - Real-time authorization updates on top of Open-Policy; built with FastAPI, Typer, and FastAPI WebSocket pub/sub.
+- [OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite) - Self-hosted, OpenAI-compatible LLM router with BYOK, cross-provider failover, and streaming.
 - [OSBot-Fast-API](https://github.com/owasp-sbot/OSBot-Fast-API) - Type-safe FastAPI wrapper that provides middleware, HTTP event tracking, AWS Lambda integration, test utilities, and auto-conversion between Type_Safe, Pydantic, and dataclasses.
 - [Polar](https://github.com/polarsource/polar) - A funding and monetization platform for developers, built with FastAPI, SQLAlchemy, Alembic, and Arq.
 - [RealWorld Example App - mongo](https://github.com/markqiu/fastapi-mongodb-realworld-example-app)


### PR DESCRIPTION
Adds OrcaRouter Lite to Projects → Open Source Projects.

A FastAPI application: self-hosted, OpenAI-compatible LLM router that takes your own provider keys and routes across 100+ models with automatic failover, streaming, and `model="auto"` selection by cost, latency, or quality. MIT licensed, actively maintained, ships with Docker/compose.

- Placed alphabetically between OPAL and OSBot-Fast-API
- One-line addition

Disclosure: I contribute to OrcaRouter Lite.
